### PR TITLE
Added to models fields and fix some bugs

### DIFF
--- a/fuel-api/db.py
+++ b/fuel-api/db.py
@@ -9,17 +9,17 @@ petrol_station_db = [
         "id": 1,
         "name": "Auchan",
         "sold_petroleum": [],
-        "City": "",
-        "Street": "",
-        "Active": "",
+        "city": "",
+        "street": "",
+        "active": False,
     },
     {
         "id": 2,
         "name": "BP",
         "sold_petroleum": [],
-        "City": "",
-        "Street": "",
-        "Active": "",
+        "city": "",
+        "street": "",
+        "active": False,
     },
 ]
 

--- a/fuel-api/main.py
+++ b/fuel-api/main.py
@@ -14,10 +14,12 @@ app = FastAPI()
 
 
 @app.get(
-    "/fuels/", response_model=list[Petroleum], response_model_exclude={"description"}
+    "/fuels/",
+    response_model=list[Petroleum],
+    response_model_exclude=["description", "created_at"],
 )
 async def read_fuels(
-    skip: int = Query(default=0, gt=0, lt=5),
+    skip: int = Query(default=0, ge=0, lt=5),
     limit: int = Query(default=10, gt=0, lt=1000),
 ):
     return petrol_db[skip : skip + limit]
@@ -42,7 +44,10 @@ async def create_fuel(petroleum: Petroleum):
     return petroleum
 
 
-@app.post("/fuels/custom_date", response_model=Petroleum)
+@app.post(
+    "/fuels/custom_date",
+    response_model=Petroleum,
+)
 async def create_fuel_with_date(
     petroleum: Petroleum,
     created_at: datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -56,7 +61,7 @@ async def create_fuel_with_date(
 
 @app.get("/petrol_stations/", response_model=list[PetrolStation])
 async def read_petrol_stations(
-    skip: int = Query(default=0, gt=0, lt=5),
+    skip: int = Query(default=0, ge=0, lt=5),
     limit: int = Query(default=10, gt=0, lt=1000),
 ):
     return petrol_station_db[skip : skip + limit]
@@ -99,7 +104,7 @@ async def create_petrol_station_with_date(
     "/prices/", response_model=list[PetrolPrice], response_model_exclude={"created_at"}
 )
 async def read_petrol_price(
-    skip: int = Query(default=0, gt=0, lt=5),
+    skip: int = Query(default=0, ge=0, lt=5),
     limit: int = Query(default=10, gt=0, lt=1000),
 ):
     return petrol_price_db[skip : skip + limit]

--- a/fuel-api/main.py
+++ b/fuel-api/main.py
@@ -83,6 +83,18 @@ async def create_petrol_station(petrol_station: PetrolStation):
     return petrol_station
 
 
+@app.post("/petrol_stations/custom_date", response_model=PetrolStation)
+async def create_petrol_station_with_date(
+    petrol_station: PetrolStation,
+    created_at: datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    updated_at: datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+):
+    petrol_station.updated_at = updated_at
+    petrol_station.created_at = created_at
+    petrol_station_db.append(petrol_station)
+    return petrol_station
+
+
 @app.get(
     "/prices/", response_model=list[PetrolPrice], response_model_exclude={"created_at"}
 )

--- a/fuel-api/main.py
+++ b/fuel-api/main.py
@@ -32,7 +32,7 @@ async def read_fuel(
     if item_dic:
         return item_dic[0]
     else:
-        return f"No entry of petrol in database for id {fuel_id}"
+        return Petroleum(id=-1, description=f"No fuel with that ID {fuel_id}")
 
 
 @app.post("/fuels/", response_model=Petroleum)
@@ -57,7 +57,11 @@ async def read_petrol_station(
     if item_dic:
         return item_dic[0]
     else:
-        return f"No entry of petrol station in database for id {petrol_station_id}"
+        return PetrolStation(
+            id=-1,
+            name=f"No petrol station with that ID {petrol_station_id}",
+            active=False,
+        )
 
 
 @app.post("/petrol_stations/", response_model=PetrolStation)

--- a/fuel-api/main.py
+++ b/fuel-api/main.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from db import petrol_db
 from db import petrol_price_db
 from db import petrol_station_db
@@ -7,7 +9,6 @@ from fastapi import Query
 from models import Petroleum
 from models import PetrolPrice
 from models import PetrolStation
-
 
 app = FastAPI()
 
@@ -37,6 +38,18 @@ async def read_fuel(
 
 @app.post("/fuels/", response_model=Petroleum)
 async def create_fuel(petroleum: Petroleum):
+    petrol_db.append(petroleum)
+    return petroleum
+
+
+@app.post("/fuels/custom_date", response_model=Petroleum)
+async def create_fuel_with_date(
+    petroleum: Petroleum,
+    created_at: datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    updated_at: datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+):
+    petroleum.updated_at = updated_at
+    petroleum.created_at = created_at
     petrol_db.append(petroleum)
     return petroleum
 

--- a/fuel-api/models.py
+++ b/fuel-api/models.py
@@ -32,12 +32,12 @@ class Petroleum(BaseModel):
         example=8,
         default=1.00,
     )
-    created_at: datetime = Field(
+    created_at: Union[datetime, None] = Field(
         title="Creation time",
         example="2021-07-20 16:26:24",
         default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     )
-    updated: datetime = Field(
+    updated: Union[datetime, None] = Field(
         title="Creation time",
         example="2021-07-20 16:26:24",
         default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -57,6 +57,8 @@ class PetrolStation(BaseModel):
     address: Union[str, None] = None
     image: Union[Image, None] = None
     active: bool
+    created_at: Union[datetime, None] = None
+    updated_at: Union[datetime, None] = None
 
 
 class PetrolPrice(BaseModel):
@@ -80,8 +82,13 @@ class PetrolPrice(BaseModel):
         gt=0,
         example=1,
     )
-    created_at: datetime = Field(
-        title="",
-        example="",
-        default=datetime.now(),
+    created_at: Union[datetime, None] = Field(
+        title="Creation time",
+        example="2021-07-20 16:26:24",
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    )
+    updated: Union[datetime, None] = Field(
+        title="Creation time",
+        example="2021-07-20 16:26:24",
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     )

--- a/fuel-api/models.py
+++ b/fuel-api/models.py
@@ -37,7 +37,7 @@ class Petroleum(BaseModel):
         example="2021-07-20 16:26:24",
         default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     )
-    updated: Union[datetime, None] = Field(
+    updated_at: Union[datetime, None] = Field(
         title="Creation time",
         example="2021-07-20 16:26:24",
         default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -87,7 +87,7 @@ class PetrolPrice(BaseModel):
         example="2021-07-20 16:26:24",
         default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     )
-    updated: Union[datetime, None] = Field(
+    updated_at: Union[datetime, None] = Field(
         title="Creation time",
         example="2021-07-20 16:26:24",
         default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),

--- a/fuel-api/models.py
+++ b/fuel-api/models.py
@@ -38,14 +38,14 @@ class Petroleum(BaseModel):
         default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     )
     updated_at: Union[datetime, None] = Field(
-        title="Creation time",
+        title="Update time",
         example="2021-07-20 16:26:24",
         default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
 
 class Image(BaseModel):
-    url: HttpUrl
+    url: HttpUrl = Field("https://default_value.org/")
     name: Union[str, None] = None
 
 
@@ -57,8 +57,16 @@ class PetrolStation(BaseModel):
     address: Union[str, None] = None
     image: Union[Image, None] = None
     active: bool
-    created_at: Union[datetime, None] = None
-    updated_at: Union[datetime, None] = None
+    created_at: Union[datetime, None] = Field(
+        title="Creation time",
+        example="2021-07-20 16:26:24",
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    )
+    updated_at: Union[datetime, None] = Field(
+        title="Update time",
+        example="2021-07-20 16:26:24",
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    )
 
 
 class PetrolPrice(BaseModel):
@@ -82,13 +90,8 @@ class PetrolPrice(BaseModel):
         gt=0,
         example=1,
     )
-    created_at: Union[datetime, None] = Field(
-        title="Creation time",
-        example="2021-07-20 16:26:24",
-        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-    )
-    updated_at: Union[datetime, None] = Field(
-        title="Creation time",
-        example="2021-07-20 16:26:24",
-        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    created_at: datetime = Field(
+        title="",
+        example="",
+        default=datetime.now(),
     )

--- a/fuel-api/models.py
+++ b/fuel-api/models.py
@@ -32,6 +32,16 @@ class Petroleum(BaseModel):
         example=8,
         default=1.00,
     )
+    created_at: datetime = Field(
+        title="Creation time",
+        example="2021-07-20 16:26:24",
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    )
+    updated: datetime = Field(
+        title="Creation time",
+        example="2021-07-20 16:26:24",
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    )
 
 
 class Image(BaseModel):


### PR DESCRIPTION
Added created_at and updated_at to models. Added two endpoints to add fuel and petrol station with custom date. Fix some bugs:
- skip needs to have ge, not gt to work with default value
- information with getting specific fuel and petrol station wasn't properly returned. right now it's returnig object with changed field with information and id equal -1